### PR TITLE
Fix tab activation logic

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -30,4 +30,13 @@ describe('AppComponent', () => {
       'resume-page app is running!'
     );
   });
+
+  it('should activate the clicked tab', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    const app = fixture.componentInstance;
+    app.tabList.forEach((t) => (t.active = false));
+    app.tabClick('work');
+    expect(app.tabList.find((t) => t.name === 'work')?.active).toBeTrue();
+    expect(app.tabList.filter((t) => t.name !== 'work').every((t) => !t.active)).toBeTrue();
+  });
 });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -70,7 +70,7 @@ export class AppComponent {
     return isMobileDevice;
   }
   tabClick(name: string) {
-    this.tabList.find((item) => {
+    this.tabList.forEach((item) => {
       item.active = name === item.name;
     });
   }

--- a/src/app/detail-bar/detail-bar.component.spec.ts
+++ b/src/app/detail-bar/detail-bar.component.spec.ts
@@ -19,4 +19,14 @@ describe('DetailBarComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should activate the clicked tab', () => {
+    component.detail = [
+      { name: 'a', active: false },
+      { name: 'b', active: false },
+    ];
+    component.tabClick('b');
+    expect(component.detail.find((d) => d.name === 'b')?.active).toBeTrue();
+    expect(component.detail.find((d) => d.name === 'a')?.active).toBeFalse();
+  });
 });

--- a/src/app/detail-bar/detail-bar.component.ts
+++ b/src/app/detail-bar/detail-bar.component.ts
@@ -18,7 +18,7 @@ export class DetailBarComponent implements OnInit {
   }
   ngOnInit(): void {}
   tabClick(name: string) {
-    this.detail.find((item: { active: boolean; name: string }) => {
+    this.detail.forEach((item: { active: boolean; name: string }) => {
       item.active = name === item.name;
     });
   }


### PR DESCRIPTION
## Summary
- fix tab activation logic on profile tabs by using `forEach`
- add tests for tab activation logic in app component and detail bar component

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fefd2b5608323922fa90251e56c82